### PR TITLE
Lowered BiCSTAB tolerance for CMFD solver to old value

### DIFF
--- a/src/scarabee/_scarabee/cmfd.cpp
+++ b/src/scarabee/_scarabee/cmfd.cpp
@@ -1007,7 +1007,7 @@ void CMFD::power_iteration(double keff) {
   // Create a solver for the problem
   Eigen::BiCGSTAB<Eigen::SparseMatrix<double>> solver;
   solver.compute(M_);
-  solver.setTolerance(1.E-15);
+  solver.setTolerance(1.E-10);
   if (solver.info() != Eigen::Success) {
     std::stringstream mssg;
     mssg << "Could not initialize CMFD iterative solver";


### PR DESCRIPTION
The BiCSTAB tolerance for the CMFD power iteration solver was set to 1E-15 as a test, but that is unnecessarily low and should be changed to 1E-10 which is the same as what is used for the fixed source solve. 